### PR TITLE
fix: conserta tabelas de requisitos quebradas

### DIFF
--- a/docs/relatorio/editaveis/04_termodeaberturadoprojeto.tex
+++ b/docs/relatorio/editaveis/04_termodeaberturadoprojeto.tex
@@ -87,17 +87,16 @@ De forma mais ampla, o projeto apresenta relevância indireta para o setor tecno
 
 % Exemplo de referência a um requisito: \cref{req:login}.
 
-\begin{longtable}{l l p{8cm}}
+\begin{longtable}{l p{3cm} p{11cm}}
     \caption{Requisitos Funcionais} \\
     \toprule
     ID & Nome & Descrição \\
     \midrule
     \endfirsthead
+    \toprule
+    ID & Nome & Descrição \\
+    \midrule
     \endhead
-    \endfoot
-    \bottomrule
-    \endlastfoot
-
     \rf[tof-paredes]{Detecção de paredes do labirinto}{
         O sistema deve detectar a presença ou ausência de paredes
         nas direções frontal, lateral esquerda e lateral direita
@@ -179,17 +178,16 @@ De forma mais ampla, o projeto apresenta relevância indireta para o setor tecno
     \rf[bat-proteção]{Proteção contra descarga profunda}{ O sistema deve interromper automaticamente o funcionamento quando a bateria atingir um nível crítico mínimo, evitando danos permanentes à bateria.}
 \end{longtable}
 
-
-\begin{longtable}{l l p{8cm}}
+\begin{longtable}{l p{3cm} p{11cm}}
     \caption{Requisitos Não Funcionais} \\
     \toprule
     ID & Nome & Descrição \\
     \midrule
     \endfirsthead
+    \toprule
+    ID & Nome & Descrição \\
+    \midrule
     \endhead
-    \endfoot
-    \bottomrule
-    \endlastfoot
     \rnf[autonomia_operacao]{Autonomia de operação}{Garantir funcionamento ininterrupto do sistema por, no mínimo, 20 minutos.} \\
     \rnf[ciclo_missao]{Ciclo de missão}{Suportar o mapeamento completo no labirinto 16x16 sem recarga..} \\
     \rnf[eficiencia_conversao]{Eficiência de conversão}{Utilizar reguladores de tensão com rendimento energético mínimo de 85\%.} \\
@@ -243,7 +241,7 @@ De forma mais ampla, o projeto apresenta relevância indireta para o setor tecno
     \rnf[responsividade_web]{Responsividade da interface}{
         A interface web deve adaptar-se automaticamente a diferentes resoluções, garantindo a ausência de elementos cortados ou sobrepostos.} \\
     \rnf[compatibilidade_browser]{Compatibilidade de navegadores}{
-        O sistema web deve ser totalmente funcional e manter a integridade visual nos navegadores baseados nas engines Chromium (Chrome, Brave, Opera, Edge) e WebKit (Safari), em suas versões estáveis mais recentes.} \\
+        O sistema web deve ser totalmente funcional e manter a integridade visual nos navegadores baseados nas engines Chromium (Chrome, Brave, Opera, Edge) e WebKit (Safari), em suas versões estáveis mais recentes.}
 \end{longtable}
 
 \section{Justificativa}

--- a/docs/relatorio/relatorio.tex
+++ b/docs/relatorio/relatorio.tex
@@ -10,6 +10,8 @@
 \usepackage{hyperref} 
 \usepackage{xparse}
 \usepackage{cleveref}
+\usepackage{longtable}
+\usepackage{booktabs}
 
 \newcounter{rfcounter}
 \newcounter{rnfcounter}
@@ -33,7 +35,7 @@
     \checkduplicatelabel{#1}%
     \label{req:#1}%
   }%
-  RF\therfcounter & #2 & #3  \\
+  RF\therfcounter & #2 & #3
 }
 
 \NewDocumentCommand{\rnf}{O{} m m}{%
@@ -42,7 +44,7 @@
     \checkduplicatelabel{#1}%
     \label{req:#1}%
   }%
-  RNF\thernfcounter & #2 & #3  \\
+  RNF\thernfcounter & #2 & #3
 }
 
 \begin{document}


### PR DESCRIPTION
As tabelas estavam com a largura passando da página. Para consertar isso, diminuí as larguras das colunas  definindo um tamanho fixo para as duas mais à direita. Após isso, surgiram dois alertas, que podem ser observados na imagem abaixo:
<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/af33c54a-5636-4727-8307-e35505388d8e" />

O alerta azul indica que o conteúdo não encaixou bem na linha, mas não representa risco para o arquivo, é apenas um aviso. Visualmente, isso pode ser ajustado mudando a largura das colunas, mas a medida colocada foi a que achei que melhor se encaixou.

Já o alerta vermelho diz "ignored error: Infinite glue shrinkage found in box being split", que é um erro comum do longtable. Contudo, mesmo com ele, o arquivo é compilado normalmente. Ao me deparar com esse erro, fiz uma pesquisa e, aparentemente, ele é comum ao usar longtable e não representa riscos também.
<img width="1005" height="808" alt="image" src="https://github.com/user-attachments/assets/60eb35f5-a94b-4ef1-835c-682c8d6b9f5f" />

Com isso, mesmo com os avisos deixados pelo compilador, o arquivo está compilando normalmente e o problema da largura das tabelas foi resolvido.

Closes #60 