### PR TITLE
adicionando WebSocket e criando infraestrutura básica do firmware

### DIFF
--- a/src/backend/simulador.js
+++ b/src/backend/simulador.js
@@ -45,7 +45,7 @@ function emitirDados() {
     }
 
     const pos = pathReal[passoAtual];
-    bateriaMah -= 5; // Simula a bateria caindo a cada passo
+    bateriaMah -= 5; // Simula a bateria ccaindo a cada passo
 
     // Manda a Posição
     socket.emit('post_posicao_atual', { id_corrida: idAtual, posicao: pos });

--- a/src/backend/src/telemetry/telemetry/ws-exception.filter.ts
+++ b/src/backend/src/telemetry/telemetry/ws-exception.filter.ts
@@ -30,7 +30,7 @@ export class WsValidationFilter extends BaseWsExceptionFilter{
        if (typeof callback === 'function'){
             callback(errorPayload);
        }else{
-            client.emit('exception, errorPayLoad');
+            client.emit('exception', errorPayload);
        }
    }
 }

--- a/src/firmware/XAROPi/platformio.ini
+++ b/src/firmware/XAROPi/platformio.ini
@@ -1,0 +1,8 @@
+[env:esp32-s3-devkitc-1]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    links2004/WebSockets
+    bblanchon/ArduinoJson

--- a/src/firmware/XAROPi/src/RobotState/comm/WebSocketManager.cpp
+++ b/src/firmware/XAROPi/src/RobotState/comm/WebSocketManager.cpp
@@ -1,0 +1,169 @@
+#include "WebSocketManager.h"
+#include "../config.h"
+#include <WiFi.h>
+#include <WebServer.h>
+#include <WebSocketsClient.h>
+#include <ArduinoJson.h>
+
+static WebSocketsClient _ws;
+static WebServer        _http(80);
+static String           _logBuf   = "";
+static bool             _wsReady  = false; 
+
+void WebSocketManager::log(const String& msg) {
+    String entry = "[" + String(millis() / 1000) + "s] " + msg + "<br>";
+    _logBuf = entry + _logBuf;
+    if (_logBuf.length() > 3000) _logBuf = _logBuf.substring(0, 3000);
+}
+
+// Página de monitoramento 192.168.4.1
+static void handleRoot() {
+    String html =
+        "<!DOCTYPE html><html><head><meta charset='UTF-8'>"
+        "<meta http-equiv='refresh' content='2'>"
+        "<title>XAROPi Monitor</title></head>"
+        "<body style='background:#111;color:#0f0;font-family:monospace;padding:20px'>"
+        "<h2>XAROPi — Monitor Wi-Fi</h2>"
+        "<p>Corrida: <b>" + robot.idCorrida + "</b> | "
+        "Status: <b>" + String(robot.corridaAtiva ? "RODANDO" : "PARADO") + "</b> | "
+        "Pos: <b>(" + String(robot.posX) + "," + String(robot.posY) + ")</b></p>"
+        "<div style='border:1px solid #333;padding:10px;background:#000'>" + _logBuf + "</div>"
+        "</body></html>";
+    _http.send(200, "text/html", html);
+}
+
+
+static void emit(const String& event, const String& payload) {
+    if (!_wsReady) return;
+    _ws.sendTXT("42[\"" + event + "\"," + payload + "]");
+}
+
+static void processarComando(const String& text) {
+    if (!text.startsWith("42[")) return;
+
+    JsonDocument doc;
+    if (deserializeJson(doc, text.substring(2)) != DeserializationError::Ok) {
+        WebSocketManager::log("❌ JSON inválido");
+        return;
+    }
+
+    if (strcmp(doc[0], "receiveCommand") != 0) return;
+
+    String cmd    = doc[1]["comando"].as<String>();
+    String corrida = doc[1]["id_corrida"].as<String>();
+    robot.idCorrida = corrida;
+
+    WebSocketManager::log("Comando: " + cmd);
+
+    if (cmd == "iniciar" || cmd == "continuar") {
+        robot.corridaAtiva = true;
+    } else if (cmd == "pausar") {
+        robot.corridaAtiva = false;
+    } else if (cmd == "cancelar" || cmd == "reiniciar") {
+        robot.corridaAtiva    = false;
+        robot.posX            = 0;
+        robot.posY            = 0;
+        robot.heading         = DIR_NORTH;
+        robot.chegouAoCentro  = false;
+        robot.mahRestante     = 1000;
+        robot.distancia       = 0.0f;
+        memset(robot.maze,      0,   sizeof(robot.maze));
+        memset(robot.distances, 255, sizeof(robot.distances));
+    }
+}
+
+static void onWsEvent(WStype_t type, uint8_t* payload, size_t length) {
+    String text = (char*)payload;
+
+    switch (type) {
+        case WStype_CONNECTED:
+            _wsReady = false;
+            WebSocketManager::log("🔌 TCP ok. Aguardando handshake...");
+            break;
+
+        case WStype_DISCONNECTED:
+            _wsReady = false;
+            robot.corridaAtiva = false;
+            WebSocketManager::log("🔴 Desconectado do backend.");
+            break;
+
+        case WStype_TEXT:
+            if      (text.startsWith("0"))  { _ws.sendTXT("40"); }             // handshake
+            else if (text.startsWith("40")) { _wsReady = true;
+                                              WebSocketManager::log("🟢 Pronto!"); }
+            else if (text == "2")           { _ws.sendTXT("3"); }              // heartbeat
+            else                            { processarComando(text); }
+            break;
+
+        default: break;
+    }
+}
+
+void WebSocketManager::init() {
+    WiFi.softAP(WIFI_SSID, WIFI_PASSWORD);
+    log("AP: " + String(WIFI_SSID) + " | IP: " + WiFi.softAPIP().toString());
+
+    _http.on("/", handleRoot);
+    _http.begin();
+
+    _ws.begin(BACKEND_HOST, BACKEND_PORT, WS_PATH);
+    _ws.onEvent(onWsEvent);
+    _ws.setReconnectInterval(5000);
+
+    randomSeed(analogRead(0));
+}
+
+void WebSocketManager::loop() {
+    _ws.loop();
+    _http.handleClient();
+}
+
+void WebSocketManager::emitPosicao() {
+    int posIndex = robot.posY * MAZE_SIZE + robot.posX;
+    JsonDocument doc;
+    doc["id_corrida"] = robot.idCorrida;
+    doc["posicao"]    = posIndex;
+    String s; serializeJson(doc, s);
+    emit("post_posicao_atual", s);
+}
+
+void WebSocketManager::emitNos() {
+    int posIndex = robot.posY * MAZE_SIZE + robot.posX;
+    uint8_t w = robot.maze[robot.posX][robot.posY];
+    JsonDocument doc;
+    doc["id_corrida"] = robot.idCorrida;
+    doc["id_celula"]  = posIndex;
+    doc["n"] = (bool)(w & WALL_NORTH);
+    doc["s"] = (bool)(w & WALL_SOUTH);
+    doc["l"] = (bool)(w & WALL_EAST);
+    doc["o"] = (bool)(w & WALL_WEST);
+    String s; serializeJson(doc, s);
+    emit("postNos", s);
+}
+
+void WebSocketManager::emitVelBat() {
+    static float tempoTotal = 0.0f;
+    static unsigned long lastMs = 0;
+    tempoTotal += (millis() - lastMs) / 1000.0f;
+    lastMs = millis();
+
+    JsonDocument doc;
+    doc["id_corrida"]   = robot.idCorrida;
+    doc["velocidade"]   = String(robot.velocidade, 2);
+    doc["tensao"]       = String(robot.tensao, 2);
+    doc["corrente"]     = (int)robot.corrente;
+    doc["mah_restante"] = robot.mahRestante;
+    doc["tempoMedio"]   = String(tempoTotal, 1);
+    doc["velMedia"]     = "0.38";
+    doc["distancia"]    = String(robot.distancia, 2);
+    String s; serializeJson(doc, s);
+    emit("postVelBat", s);
+}
+
+void WebSocketManager::emitFinish() {
+    JsonDocument doc;
+    doc["id_corrida"]    = robot.idCorrida;
+    doc["bateria_final"] = robot.mahRestante;
+    String s; serializeJson(doc, s);
+    emit("postFinish", s);
+}

--- a/src/firmware/XAROPi/src/RobotState/comm/WebSocketManager.h
+++ b/src/firmware/XAROPi/src/RobotState/comm/WebSocketManager.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <Arduino.h>
+
+// Gerencia toda a comunicação Socket.IO com o backend NestJS:
+//   - Cria o AP Wi-Fi e o servidor HTTP de monitoramento
+//   - Mantém a conexão WebSocket com handshake e heartbeat
+//   - Recebe comandos do backend e atualiza robot.corridaAtiva / robot.idCorrida
+//   - Expõe funções de emissão de telemetria para o main.cpp usar
+
+namespace WebSocketManager {
+
+    // Chame uma vez no setup()
+    void init();
+
+    // Chame a cada iteração do loop() — mantém WS e HTTP vivos
+    void loop();
+
+    // Adiciona uma linha no log da página web (192.168.4.1)
+    void log(const String& msg);
+
+    // ── Emissores de telemetria ──────────────────────────────────────────────
+    // Chamados pelo main.cpp após cada passo do Floodfill
+    void emitPosicao();   // Usa robot.posX, robot.posY
+    void emitNos();       // Usa robot.maze[posX][posY]
+    void emitVelBat();    // Usa robot.velocidade, robot.tensao, robot.mahRestante...
+    void emitFinish();    // Chamado quando Floodfill::finished() == true
+}

--- a/src/firmware/XAROPi/src/RobotState/motors/MotorController.h
+++ b/src/firmware/XAROPi/src/RobotState/motors/MotorController.h
@@ -1,0 +1,23 @@
+#pragma once
+
+// ─── Módulo: Controle dos Motores (L298N via PWM) ────────────────────────────
+//
+// RESPONSABILIDADE DESTE MÓDULO:
+//   Executar os movimentos físicos decididos pelo Floodfill e atualizar:
+//     robot.velocidade
+//     robot.distancia
+//
+// O Floodfill atualiza robot.heading com a direção desejada.
+// O MotorController deve girar e avançar conforme essa direção.
+//
+// TODO:
+//   - Implementar MotorController.cpp com PWM via LEDC e controle por encoder
+//   - Calibrar MS_FORWARD e MS_TURN_90 com o robô físico
+
+namespace MotorController {
+    void init();         // Configura pinos PWM e interrupções dos encoders
+    void moveForward();  // Avança uma célula (~18cm)
+    void turnRight();    // Gira 90° à direita
+    void turnLeft();     // Gira 90° à esquerda
+    void stop();
+}

--- a/src/firmware/XAROPi/src/RobotState/navigation/Floodfill.cpp
+++ b/src/firmware/XAROPi/src/RobotState/navigation/Floodfill.cpp
@@ -1,0 +1,121 @@
+#include "Floodfill.h"
+#include "../config.h"
+
+struct Cell { uint8_t x, y; };
+static Cell _queue[TOTAL_CELLS];
+static int  _head = 0, _tail = 0;
+
+static void enqueue(uint8_t x, uint8_t y) {
+    _queue[_tail] = {x, y};
+    _tail = (_tail + 1) % TOTAL_CELLS;
+}
+static Cell dequeue() {
+    Cell c = _queue[_head];
+    _head = (_head + 1) % TOTAL_CELLS;
+    return c;
+}
+static bool queueEmpty() { return _head == _tail; }
+
+static void setWallAbsoluta(int x, int y, int dir) {
+    auto& maze = robot.maze;
+    if (dir == DIR_NORTH) {
+        maze[x][y] |= WALL_NORTH;
+        if (y < MAZE_SIZE - 1) maze[x][y+1] |= WALL_SOUTH;
+    } else if (dir == DIR_EAST) {
+        maze[x][y] |= WALL_EAST;
+        if (x < MAZE_SIZE - 1) maze[x+1][y] |= WALL_WEST;
+    } else if (dir == DIR_SOUTH) {
+        maze[x][y] |= WALL_SOUTH;
+        if (y > 0) maze[x][y-1] |= WALL_NORTH;
+    } else if (dir == DIR_WEST) {
+        maze[x][y] |= WALL_WEST;
+        if (x > 0) maze[x-1][y] |= WALL_EAST;
+    }
+}
+
+static void recalcularDistancias() {
+    auto& dist = robot.distances;
+    auto& maze = robot.maze;
+
+    for (int i = 0; i < MAZE_SIZE; i++)
+        for (int j = 0; j < MAZE_SIZE; j++)
+            dist[i][j] = 255;
+
+    _head = _tail = 0;
+
+    uint8_t c1 = (MAZE_SIZE / 2) - 1;
+    uint8_t c2 = (MAZE_SIZE / 2);
+    dist[c1][c1] = 0; enqueue(c1, c1);
+    dist[c1][c2] = 0; enqueue(c1, c2);
+    dist[c2][c1] = 0; enqueue(c2, c1);
+    dist[c2][c2] = 0; enqueue(c2, c2);
+
+    while (!queueEmpty()) {
+        Cell c = dequeue();
+        uint8_t cx = c.x, cy = c.y, d = dist[cx][cy];
+
+        if (cy < MAZE_SIZE-1 && !(maze[cx][cy] & WALL_NORTH) && dist[cx][cy+1]==255)
+            { dist[cx][cy+1] = d+1; enqueue(cx, cy+1); }
+        if (cy > 0           && !(maze[cx][cy] & WALL_SOUTH) && dist[cx][cy-1]==255)
+            { dist[cx][cy-1] = d+1; enqueue(cx, cy-1); }
+        if (cx < MAZE_SIZE-1 && !(maze[cx][cy] & WALL_EAST)  && dist[cx+1][cy]==255)
+            { dist[cx+1][cy] = d+1; enqueue(cx+1, cy); }
+        if (cx > 0           && !(maze[cx][cy] & WALL_WEST)  && dist[cx-1][cy]==255)
+            { dist[cx-1][cy] = d+1; enqueue(cx-1, cy); }
+    }
+}
+
+
+static void decidirEMover() {
+    auto& dist = robot.distances;
+    auto& maze = robot.maze;
+    int x = robot.posX, y = robot.posY;
+
+    uint8_t minDist = 255;
+    int bestDir = robot.heading;
+
+    if (y < MAZE_SIZE-1 && !(maze[x][y] & WALL_NORTH) && dist[x][y+1] < minDist)
+        { minDist = dist[x][y+1]; bestDir = DIR_NORTH; }
+    if (x < MAZE_SIZE-1 && !(maze[x][y] & WALL_EAST)  && dist[x+1][y] < minDist)
+        { minDist = dist[x+1][y]; bestDir = DIR_EAST;  }
+    if (y > 0           && !(maze[x][y] & WALL_SOUTH) && dist[x][y-1] < minDist)
+        { minDist = dist[x][y-1]; bestDir = DIR_SOUTH; }
+    if (x > 0           && !(maze[x][y] & WALL_WEST)  && dist[x-1][y] < minDist)
+        { minDist = dist[x-1][y]; bestDir = DIR_WEST;  }
+
+    robot.heading = bestDir;
+
+    if      (robot.heading == DIR_NORTH) robot.posY++;
+    else if (robot.heading == DIR_EAST)  robot.posX++;
+    else if (robot.heading == DIR_SOUTH) robot.posY--;
+    else if (robot.heading == DIR_WEST)  robot.posX--;
+}
+
+void Floodfill::init() {
+    memset(robot.maze,      0,   sizeof(robot.maze));
+    memset(robot.distances, 255, sizeof(robot.distances));
+    robot.posX           = 0;
+    robot.posY           = 0;
+    robot.heading        = DIR_NORTH;
+    robot.chegouAoCentro = false;
+    recalcularDistancias();
+}
+
+// 1 ciclo completo: lê paredes → atualiza mapa → recalcula → decide
+// Lê robot.wallFront/Right/Left (preenchidos pelo IRSensors antes desta chamada)
+void Floodfill::step() {
+    int dirFront = robot.heading;
+    int dirRight = (robot.heading + 1) % 4;
+    int dirLeft  = (robot.heading + 3) % 4;
+
+    if (robot.wallFront) setWallAbsoluta(robot.posX, robot.posY, dirFront);
+    if (robot.wallRight) setWallAbsoluta(robot.posX, robot.posY, dirRight);
+    if (robot.wallLeft)  setWallAbsoluta(robot.posX, robot.posY, dirLeft);
+
+    recalcularDistancias();
+    decidirEMover();
+}
+
+bool Floodfill::finished() {
+    return robot.distances[robot.posX][robot.posY] == 0;
+}

--- a/src/firmware/XAROPi/src/RobotState/navigation/Floodfill.h
+++ b/src/firmware/XAROPi/src/RobotState/navigation/Floodfill.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// Algoritmo Flood Fill.
+//
+// O while(true) do algoritmo original foi substituído por step(), que executa um ciclo
+// completo por chamada: lê robot.wall* → atualiza robot.maze →
+// recalcula robot.distances → move (via robot.posX/Y/heading).
+//
+// Isso libera o loop() principal para manter o WebSocket ativo entre passos.
+//
+// antes de chamar step(), o módulo de sensores (IRSensors)
+// deve ter atualizado robot.wallFront / robot.wallRight / robot.wallLeft.
+
+namespace Floodfill {
+    void init();      // Reseta maze, distances e posição — chamar no setup()
+    void step();      // Executa um passo — chamar a cada STEP_INTERVAL_MS
+    bool finished();  // true quando robot.distances[posX][posY] == 0
+}

--- a/src/firmware/XAROPi/src/RobotState/sensors/BatteryMonitor.h
+++ b/src/firmware/XAROPi/src/RobotState/sensors/BatteryMonitor.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// ─── Módulo: Leitura da Bateria ───────────────────────────────────────────────
+//
+// RESPONSABILIDADE DESTE MÓDULO:
+//   Ler tensão e corrente do hardware e atualizar no RobotState:
+//     robot.tensao       (V)
+//     robot.corrente     (mA)
+//     robot.mahRestante
+//
+// O WebSocketManager::emitVelBat() já envia esses valores automaticamente
+// a cada TELEMETRY_INTERVAL_MS — nenhuma chamada extra necessária.
+//
+// TODO:
+//   - Implementar BatteryMonitor.cpp com leitura real do hardware
+//   - Remover a simulação `robot.mahRestante -= 5` do main.cpp ao integrar
+
+namespace BatteryMonitor {
+    void init();   // Configura pino analógico ou I2C do sensor de bateria
+    void read();   // Atualiza robot.tensao / robot.corrente / robot.mahRestante
+}

--- a/src/firmware/XAROPi/src/RobotState/sensors/IRSensors.h
+++ b/src/firmware/XAROPi/src/RobotState/sensors/IRSensors.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// ─── Módulo: Leitura dos Sensores de Parede (VL53L0X via I2C) ────────────────
+//
+// RESPONSABILIDADE DESTE MÓDULO:
+//   Ler os sensores ToF e atualizar no RobotState:
+//     robot.wallFront
+//     robot.wallRight
+//     robot.wallLeft
+//
+// O Floodfill::step() consome esses valores — ele deve ser chamado
+// DEPOIS de IRSensors::read() em cada ciclo.
+//
+// TODO:
+//   - Implementar IRSensors.cpp com leitura real dos VL53L0X (TOF)
+//   - Definir o limiar de distância que configura uma parede (ex: 80mm, 100mm, etc)
+
+namespace IRSensors {
+    void init();   // Inicializa I2C e os sensores
+    void read();   // Atualiza robot.wallFront / wallRight / wallLeft
+}

--- a/src/firmware/XAROPi/src/config.h
+++ b/src/firmware/XAROPi/src/config.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <Arduino.h>
+
+// ─── Rede ─────────────────────────────────────────────────────────────────────
+#define WIFI_SSID       "ESP32_S3_WIFI"
+#define WIFI_PASSWORD   "senha_segura_123"
+#define BACKEND_HOST    "192.168.4.2"
+#define BACKEND_PORT    3000
+#define WS_PATH         "/socket.io/?EIO=4&transport=websocket&role=esp32"
+
+// ─── Labirinto ────────────────────────────────────────────────────────────────
+#define MAZE_SIZE       16
+#define TOTAL_CELLS     (MAZE_SIZE * MAZE_SIZE)
+
+#define DIR_NORTH       0
+#define DIR_EAST        1
+#define DIR_SOUTH       2
+#define DIR_WEST        3
+
+#define WALL_NORTH      0x01
+#define WALL_EAST       0x02
+#define WALL_SOUTH      0x04
+#define WALL_WEST       0x08
+
+// ─── Timing ───────────────────────────────────────────────────────────────────
+#define STEP_INTERVAL_MS      1000   // Intervalo entre passos do Floodfill
+#define TELEMETRY_INTERVAL_MS  200   // Intervalo de envio de telemetria (5 Hz)
+
+// =============================================================================
+// Estado global compartilhado entre todos os módulos.
+//
+// REGRA: cada módulo escreve APENAS no seu bloco. Nunca no bloco alheio.
+//   - WebSocketManager  → controle (corridaAtiva, idCorrida)
+//   - Floodfill         → navegação (posX, posY, heading, maze, distances)
+//   - IRSensors (TODO)  → sensores (wallFront, wallRight, wallLeft)
+//   - MotorController   → odometria (velocidade, distancia)
+//   - BatteryMonitor    → bateria (tensao, corrente, mahRestante)
+// =============================================================================
+struct RobotState {
+
+    // — Controle de corrida (WebSocketManager) —
+    bool    corridaAtiva   = false;
+    String  idCorrida      = "";
+
+    // — Navegação (Floodfill) —
+    int     posX           = 0;
+    int     posY           = 0;
+    int     heading        = DIR_NORTH;
+    bool    chegouAoCentro = false;
+    uint8_t maze[MAZE_SIZE][MAZE_SIZE]      = {};
+    uint8_t distances[MAZE_SIZE][MAZE_SIZE] = {};
+
+    // — Sensores de parede (IRSensors — a implementar) —
+    bool    wallFront      = false;
+    bool    wallRight      = false;
+    bool    wallLeft       = false;
+
+    // — Odometria (MotorController — a implementar) —
+    float   velocidade     = 0.0f;   // m/s
+    float   distancia      = 0.0f;   // metros
+
+    // — Bateria (BatteryMonitor — a implementar) —
+    float   tensao         = 7.4f;   // V
+    float   corrente       = 0.0f;   // mA
+    int     mahRestante    = 1000;
+};
+
+// Instância única definida em main.cpp, acessível por todos via extern
+extern RobotState robot;

--- a/src/firmware/XAROPi/src/main.cpp
+++ b/src/firmware/XAROPi/src/main.cpp
@@ -1,0 +1,70 @@
+#include <Arduino.h>
+#include "config.h"
+#include "comm/WebSocketManager.h"
+#include "navigation/Floodfill.h"
+
+// #include "sensors/BatteryMonitor.h"
+// #include "sensors/IRSensors.h"
+// #include "motors/MotorController.h"
+
+
+// ─── Instância global do estado compartilhado ─────────────────────────────────
+RobotState robot;
+
+// ─── Timers ───────────────────────────────────────────────────────────────────
+static unsigned long lastStepMs      = 0;
+static unsigned long lastTelemetryMs = 0;
+
+void setup() {
+    WebSocketManager::init();
+    Floodfill::init();
+
+    // IRSensors::init();      // TODO: descomentar quando pronto
+    // MotorController::init(); // TODO: descomentar quando pronto
+}
+
+void loop() {
+    WebSocketManager::loop();
+
+    if (!robot.corridaAtiva) return;
+
+    unsigned long now = millis();
+
+    // Um passo do Floodfill a cada STEP_INTERVAL_MS
+    if (now - lastStepMs >= STEP_INTERVAL_MS) {
+        lastStepMs = now;
+
+        if (Floodfill::finished()) {
+            robot.corridaAtiva    = false;
+            robot.chegouAoCentro  = true;
+            WebSocketManager::emitFinish();
+            WebSocketManager::log("🏁 Centro alcançado!");
+            return;
+        }
+
+        // TODO: descomentar quando IRSensors estiver pronto
+        // IRSensors::read();  // Atualiza robot.wallFront/Right/Left
+
+        // Simulação temporária de paredes (remover quando IRSensors estiver pronto)
+        robot.wallFront = false;
+        robot.wallRight = false;
+        robot.wallLeft  = false;
+
+        Floodfill::step();
+
+        // TODO: descomentar quando MotorController estiver pronto
+        // MotorController::moveForward(); — o Floodfill já calcula heading,
+        // o MotorController só precisa executar fisicamente
+
+        // Simula queda de bateria (remover quando BatteryMonitor estiver pronto)
+        robot.mahRestante -= 5;
+    }
+
+    // Telemetria a cada TELEMETRY_INTERVAL_MS
+    if (now - lastTelemetryMs >= TELEMETRY_INTERVAL_MS) {
+        lastTelemetryMs = now;
+        WebSocketManager::emitPosicao();
+        WebSocketManager::emitNos();
+        WebSocketManager::emitVelBat();
+    }
+}


### PR DESCRIPTION
## Descrição do PR

Este Pull Request introduz a implementação inicial da comunicação via **WebSocket** e estabelece uma **arquitetura modular** para o firmware do sistema, mitigando problemas de acoplamento e preparando o ambiente para o desenvolvimento paralelo das subequipes.

A lógica de comunicação foi validada localmente utilizando dados simulados (mockados), integrados em conformidade com o comportamento do `simulador.js` presente na pasta do backend.

---

## Arquitetura e Estrutura de Diretórios

A estrutura do firmware foi organizada dentro do diretório `firmware/XAROPi/`, sendo segmentada em quatro módulos principais:

* **`comm/`**: Centraliza a configuração da conexão Wi-Fi e a lógica do cliente WebSocket.
* **`navigation/`**: Contém os algoritmos de tomada de decisão. A implementação do algoritmo Floodfill foi adaptada para rodar de forma que não bloqueie o loop principal do programa, garantindo que o WebSocket fique ativo o tempo todo.
* **`sensors/`**: Módulo dedicado à leitura e tratamento de dados dos sensores ToFs e gerenciamento de bateria.
* **`motors/`**: Responsável pelo controle dinâmico de movimentação, englobando aceleração, frenagem, curvas e trajetórias.

Adicionalmente, os arquivos de configuração global do projeto foram centralizados na pasta `src/`.

---

## Detalhes da Implementação e Padronização (.h)

Para permitir que os outros membros trabalhem simultaneamente sem gerar conflitos de integração ou acoplamento, foram criados arquivos de cabeçalho (`.h`) personalizáveis nas pastas `sensors/` e `motors/`:

1.  **Interfaces Definidas**: Esses arquivos funcionam como um guia de instrução, **delimitando** as funções e o escopo do que cada integrante de firmware precisa implementar.
2.  **Documentação e Lógica Interconectada**: O fluxo principal já está completamente amarrado a essas funções. Há comentários detalhados no código indicando as responsabilidades de cada bloco e o formato esperado de retorno.
3.  **Transição para o Hardware**: No estágio atual, o firmware consome dados simulados para validar a arquitetura. À medida que o código de leitura dos componentes físicos for finalizado, bastará descomentar as seções devidamente assinaladas nos arquivos para alternar da simulação para a operação real.

---
