### PR TITLE
Feat/consulta historico

### DIFF
--- a/src/backend/src/firebase/firebase.service.ts
+++ b/src/backend/src/firebase/firebase.service.ts
@@ -49,7 +49,7 @@ export class FirebaseService implements OnModuleInit {
     console.log('Firebase Realtime Database conectado via JSON Template + .env!');
   }
 
-  async saveTelemetry(data: any) {
+  async saveTelemetry(data: any): Promise<any> {
     const ref = this.db.ref('telemetry');
     return await ref.push(data);
   }

--- a/src/backend/src/telemetry/telemetry/telemetry.gateway.spec.ts
+++ b/src/backend/src/telemetry/telemetry/telemetry.gateway.spec.ts
@@ -34,7 +34,6 @@ describe('TelemetryGateway', () => {
 
     gateway = module.get<TelemetryGateway>(TelemetryGateway);
 
-    // Corrige o erro "Cannot read properties of undefined (reading 'to')"
     gateway.server = {
       to: mockTo,
       emit: mockEmit,
@@ -112,13 +111,32 @@ describe('TelemetryGateway', () => {
     });
   });
 
-  describe('sendcomand', () => {
-    it('deve encaminhar o comando e retornar sucesso', async () => {
+ describe('sendcomand', () => {
+    it('deve encaminhar o comando "iniciar" e retornar sucesso', async () => {
       const dto = { id_corrida: 'fake-id-123', comando: 'iniciar' };
+      
+      const clientMock = { id: 'fake-client-id' } as any;
 
-      const resultado = await gateway.handleSendCommand(dto);
+      const resultado = await gateway.handleSendCommand(dto, clientMock);
 
       expect(mockEmit).toHaveBeenCalledWith('receiveCommand', dto);
+      expect(resultado).toEqual({ status: 'comando_encaminhado' });
+    });
+
+    it('deve atualizar o banco e avisar a sala ao enviar comando "cancelar"', async () => {
+      const dto = { id_corrida: 'fake-id-123', comando: 'cancelar' };
+      const clientMock = { id: 'fake-client-id' } as any;
+
+      (gateway as any).corridasAtivas.set(clientMock.id, dto.id_corrida);
+
+      const resultado = await gateway.handleSendCommand(dto, clientMock);
+
+      expect(mockEmit).toHaveBeenCalledWith('receiveCommand', dto);
+      
+      expect(mockRef.update).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'interrompida',
+      }));
+
       expect(resultado).toEqual({ status: 'comando_encaminhado' });
     });
   });
@@ -126,7 +144,6 @@ describe('TelemetryGateway', () => {
   describe('handleDisconnect', () => {
     it('deve marcar corrida como interrompida se cliente tinha corrida ativa', async () => {
       const clienteMock = { id: 'socket-123' } as any;
-      // Simula que esse cliente tinha uma corrida ativa
       (gateway as any).corridasAtivas.set('socket-123', 'fake-id-123');
 
       await gateway.handleDisconnect(clienteMock);

--- a/src/backend/src/telemetry/telemetry/telemetry.gateway.ts
+++ b/src/backend/src/telemetry/telemetry/telemetry.gateway.ts
@@ -7,6 +7,7 @@ import {
     OnGatewayConnection,
     OnGatewayDisconnect
 } from '@nestjs/websockets';
+
 import { Server, Socket } from 'socket.io';
 import { FirebaseService } from '../../firebase/firebase.service';
 import { PostStartDto } from '../dto/post-start.dto';
@@ -17,6 +18,7 @@ import { PostPosicaoAtualDto } from '../dto/post-posicao-atual.dto';
 import { SendCommandDto } from '../dto/send-command.dto';
 import { UsePipes, UseFilters, ValidationPipe } from '@nestjs/common';
 import { WsValidationFilter } from './ws-exception.filter';
+import { timestamp } from 'rxjs';
 
 @WebSocketGateway({ cors: true })
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
@@ -134,7 +136,6 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
 
     await telemetriaRef.set(novaLeitura);
 
-    // Notifica o canal de telemetria viva e o canal geral esperado pelas views
     this.server.to('telemetria_viva_room').emit('telemetria_viva', novaLeitura);
     this.server.emit('novaTelemetria', data);
 
@@ -168,8 +169,24 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
   }
 
   @SubscribeMessage('sendcomand')
-  async handleSendCommand(@MessageBody() data: SendCommandDto) {
+  async handleSendCommand(@MessageBody() data: SendCommandDto, @ConnectedSocket() client: Socket) {
     this.server.emit('receiveCommand', data);
+    if (data.comando === 'cancelar'){
+      const db = this.firebaseService.getDb();
+      const metadadosRef = db.ref(`corridas/${data.id_corrida}/metadados`);
+
+      await metadadosRef.update({
+        status: 'interrompida',
+        fim_timestamp: Date.now()
+      });
+
+      this.server.to('telemetria_viva_room').emit('novaTelemetria', {
+        status: 'interrompida',
+        timestamp: Date.now()
+      });
+      
+      this.corridasAtivas.delete(client.id);
+    }
     return { status: 'comando_encaminhado' };
   }
 

--- a/src/backend/src/telemetry/telemetry/telemetry.gateway.ts
+++ b/src/backend/src/telemetry/telemetry/telemetry.gateway.ts
@@ -18,7 +18,6 @@ import { PostPosicaoAtualDto } from '../dto/post-posicao-atual.dto';
 import { SendCommandDto } from '../dto/send-command.dto';
 import { UsePipes, UseFilters, ValidationPipe } from '@nestjs/common';
 import { WsValidationFilter } from './ws-exception.filter';
-import { timestamp } from 'rxjs';
 
 @WebSocketGateway({ cors: true })
 @UsePipes(new ValidationPipe({ transform: true, whitelist: true, forbidNonWhitelisted: true }))
@@ -30,6 +29,8 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
 
   private corridasAtivas: Map<string, string> = new Map();
   private corridaAtual: string | null = null;
+  // Mapa para guardar a última posição conhecida por corrida
+  private ultimaPosicao: Map<string, number> = new Map(); 
 
   constructor(private readonly firebaseService: FirebaseService) {}
 
@@ -91,6 +92,7 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
     const idCorrida = novaCorridaRef.key as string;
     this.corridasAtivas.set(client.id, idCorrida);
     this.corridaAtual = idCorrida;
+    this.ultimaPosicao.set(idCorrida, 0); // Inicializa posição em 0
 
     await novaCorridaRef.set({
       metadados: {
@@ -126,18 +128,22 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
     const db = this.firebaseService.getDb();
     const telemetriaRef = db.ref(`corridas/${data.id_corrida}/telemetria`).push();
       
+    // Pega a última posição conhecida ou 0 caso não exista
+    const posicaoAtual = this.ultimaPosicao.get(data.id_corrida) ?? 0;
+
     const novaLeitura = {
       timestamp: Date.now(),
       velocidade: data.velocidade,
       corrente: data.corrente,
       tensao: data.tensao,
-      mah_restante: data.mah_restante
+      mah_restante: data.mah_restante,
+      posicao_vetor: posicaoAtual // AGORA VAI SALVAR A POSIÇÃO AQUI
     };
 
     await telemetriaRef.set(novaLeitura);
 
     this.server.to('telemetria_viva_room').emit('telemetria_viva', novaLeitura);
-    this.server.emit('novaTelemetria', data);
+    this.server.emit('novaTelemetria', { ...data, posicao: posicaoAtual });
 
     return { status: 'sucesso' };
   }
@@ -154,11 +160,15 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
     });
 
     this.corridasAtivas.delete(client.id);
+    this.ultimaPosicao.delete(data.id_corrida); // Limpa memória
     return { status: 'sucesso' };
   }
 
   @SubscribeMessage('post_posicao_atual')
   async handlePostPosicaoAtual(@MessageBody() data: PostPosicaoAtualDto) {
+    // Atualiza a memória com a nova posição
+    this.ultimaPosicao.set(data.id_corrida, data.posicao);
+
     const db = this.firebaseService.getDb();
     const estadoRef = db.ref(`corridas/${data.id_corrida}/estado_atual`);
 
@@ -186,6 +196,7 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
       });
       
       this.corridasAtivas.delete(client.id);
+      this.ultimaPosicao.delete(data.id_corrida);
     }
     return { status: 'comando_encaminhado' };
   }
@@ -198,6 +209,7 @@ export class TelemetryGateway implements OnGatewayConnection, OnGatewayDisconnec
 
       await metadadosRef.update({ status: 'interrompida', fim_timestamp: Date.now() });
       this.corridasAtivas.delete(client.id);
+      this.ultimaPosicao.delete(id_corrida);
       console.log(`[ALERTA] Conexão perdida. Corrida ${id_corrida} marcada como interrompida.`);
     }
   }

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -47,8 +47,15 @@ function AppLayout() {
     };
   }, []);
 
-  const currentPage = (Object.entries(PAGE_CONFIG).find(([, config]) => config.route === location.pathname)?.[0] ?? 'dashboard') as Page;
-  const { label, description, showTopPage } = PAGE_CONFIG[currentPage];
+  const currentPage = (Object.entries(PAGE_CONFIG).find(([, config]) => 
+                                                                        location.pathname === config.route || 
+                                                                        (config.route !== '/' && location.pathname.startsWith(`${config.route}/`)))?.[0] ?? 'dashboard') as Page;
+  let { label, description, showTopPage } = PAGE_CONFIG[currentPage];
+
+  if (currentPage === 'percurso' && location.pathname.includes('/percurso/')) {
+    label = 'Consultar Percurso';
+    description = 'Visualizando dados históricos do percurso selecionado.';
+  }
   const handlePageChange = (page: Page) => navigate(PAGE_CONFIG[page].route);
   const toggleTheme = () => {
     const next = theme === 'light' ? 'dark' : 'light';
@@ -87,6 +94,7 @@ function AppLayout() {
             <Route path="/projeto" element={<Projeto />} />
             <Route path="/equipe" element={<Equipe />} />
             <Route path="/percurso" element={<Percurso />} />
+            <Route path="/percurso/:id" element={<Percurso />} /> {/* Nova Rota */}
             <Route path="/chassi" element={<Chassi3D />} />
           </Routes>
         </main>

--- a/src/frontend/src/components/Table/Table.tsx
+++ b/src/frontend/src/components/Table/Table.tsx
@@ -16,12 +16,11 @@ interface TableProps<T> {
   data: T[]
   pageSize?: number
   actions?: boolean
-  
   onDelete?: (id: string | number) => void 
+  onRowClick?: (id: string | number) => void
 }
 
-
-export function Table<T extends { id: string | number }>({ columns, data, pageSize = 10, actions = true, onDelete }: TableProps<T>) {
+export function Table<T extends { id: string | number }>({ columns, data, pageSize = 10, actions = true, onDelete, onRowClick }: TableProps<T>) {
   const [page, setPage] = useState(1)
   const [deleteId, setDeleteId] = useState<string | number | null>(null)
 
@@ -52,14 +51,14 @@ export function Table<T extends { id: string | number }>({ columns, data, pageSi
         </thead>
         <tbody>
           {paginated.map(row => (
-            <tr key={row.id}>
+            <tr key={row.id} onClick={() => onRowClick && onRowClick(row.id)} style={{ cursor: onRowClick ? 'pointer' : 'default' }}>
               {columns.map(col => (
                 <td key={String(col.key)}>
                   {col.render ? col.render(row[col.key], row) : String(row[col.key])}
                 </td>
               ))}
               {actions && (
-                <td style={{ width: '1px', whiteSpace: 'nowrap' }}>
+                <td style={{ width: '1px', whiteSpace: 'nowrap' }} onClick={(e) => e.stopPropagation()}>
                   <Button 
                     density='high' 
                     type='circle' 

--- a/src/frontend/src/config/pages.ts
+++ b/src/frontend/src/config/pages.ts
@@ -32,7 +32,7 @@ export const PAGE_CONFIG: Record<Page, {
         description: 'Membros da equipe',
     },
 
-    // label deve ser "novo percurso" se for novo ou "consultar percurso" se for percurso antigo
+   
     percurso: {
         route: '/percurso',
         label: 'Novo Percurso',

--- a/src/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -13,10 +13,14 @@ import styles from './Dashboard.module.css';
 const API_URL = import.meta.env.VITE_API_URL;
 
 const STATUS_BADGE: Record<string, 'success' | 'warn' | 'alert'> = {
-    'Concluído': 'success', 'Falhou': 'alert', 'Em curso': 'warn'
+  'Concluído': 'success', 
+  'Interrompido': 'alert', 
+  'Em curso': 'warn',
 };
 const STATUS_LABEL: Record<string, string> = {
-    'concluido': 'Concluído', 'falha': 'Falhou', 'interrompida': 'Falhou', 'em_execucao': 'Em curso'
+    'concluido': 'Concluído', 
+    'interrompida': 'Interrompido', 
+    'em_execucao': 'Em curso',
 };
 
 const safeNum = (val: any) => { const n = Number(val); return isNaN(n) ? 0 : n; };

--- a/src/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/src/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -93,10 +93,17 @@ export function Dashboard() {
                 let totalTempo = 0, totalVel = 0, totalConsumo = 0, concluidas = 0;
 
                 const formatoTabela = corridas.map(([firebaseId, corrida]: any, index) => {
-                    const ultimaTel = corrida.telemetria ? Object.values(corrida.telemetria).pop() as any : null;
-                    
-                    const duracao = safeNum(ultimaTel?.tempoMedio);
-                    const velocity = safeNum(ultimaTel?.velMedia);
+                    const inicioTs = safeNum(corrida.metadados?.inicio_timestamp);
+                    let fimTs = safeNum(corrida.metadados?.fim_timestamp);
+                    const eventos = corrida.telemetria ? (Object.values(corrida.telemetria) as any[]) : [];
+                    const ultimaTel = eventos.length > 0 ? eventos[eventos.length - 1] : null;
+
+                    if (fimTs <= 0 && ultimaTel?.timestamp) fimTs = safeNum(ultimaTel.timestamp);
+
+                    const duracao = (fimTs > inicioTs && inicioTs > 0) ? (fimTs - inicioTs) / 1000 : 0;
+                    const velocity = eventos.length > 0
+                        ? eventos.reduce((acc: number, e: any) => acc + safeNum(e.velocidade), 0) / eventos.length
+                        : 0;
                     const mahRestante = safeNum(ultimaTel?.mah_restante);
                     const consume = mahRestante > 0 ? 1000 - mahRestante : 0;
 

--- a/src/frontend/src/pages/Historico/Historico.tsx
+++ b/src/frontend/src/pages/Historico/Historico.tsx
@@ -3,12 +3,17 @@ import axios from 'axios';
 import { Table } from '../../components/Table';
 import type { Column } from '../../components/Table';
 import { Badge } from '../../components/Badge';
+import { useNavigate } from 'react-router-dom';
 
 const STATUS_BADGE: Record<string, 'success' | 'warn' | 'alert'> = {
-  'Concluído': 'success', 'Falhou': 'alert', 'Em curso': 'warn',
+  'Concluído': 'success', 
+  'Interrompido': 'alert', 
+  'Em curso': 'warn',
 };
 const STATUS_LABEL: Record<string, string> = {
-    'concluido': 'Concluído', 'falha': 'Falhou', 'interrompida': 'Falhou', 'em_execucao': 'Em curso',
+    'concluido': 'Concluído', 
+    'interrompida': 'Interrompido', 
+    'em_execucao': 'Em curso',
 };
 
 const safeNum = (val: any) => { const n = Number(val); return isNaN(n) ? 0 : n; };
@@ -32,52 +37,66 @@ const columns: Column<any>[] = [
 ];
 
 export function Historico() {
+    const navigate = useNavigate();
     const [data, setData] = useState<any[]>([]);
 
     const fetchCorridas = () => {
-        axios.get('http://localhost:3000/corridas')
-            .then(response => {
-                const dadosNode = response.data.dados;
-                if (!dadosNode) return;
+        axios.get('http://localhost:3000/corridas').then(response => {
+            const dadosNode = response.data.dados;
+            if (!dadosNode) return;
 
-                const listaCorridas = Object.entries(dadosNode);
-                const formatoTabela = listaCorridas.map(([firebaseId, corrida]: any, index) => {
-                    let distTotal = 0;
-                    const duration =  corrida.telemetria ? (safeNum(corrida.metadados.fim_timestamp) - safeNum(corrida.metadados.inicio_timestamp)) / 1000: null;
-                    let lastTimeStamp = 0;
-                    corrida.telemetria ? Object.values(corrida.telemetria).forEach( (tel) =>{
-                        let Tel = Object(tel)
-                        if(distTotal !== -1){
-                            if(lastTimeStamp === 0) {
-                                lastTimeStamp = safeNum(corrida.metadados.inicio_timestamp)
-                            }
+            const listaCorridas = Object.entries(dadosNode);
+            const formatoTabela = listaCorridas.map(([firebaseId, corrida]: any, index) => {
+                let distTotal = 0;
+                let lastTimeStamp = 0;
+                const inicioTs = safeNum(corrida.metadados?.inicio_timestamp);
+                let fimTs = safeNum(corrida.metadados?.fim_timestamp);
+                
+                const eventos = corrida.telemetria ? Object.values(corrida.telemetria) as any[] : [];
+                const ultimaTel = eventos.length > 0 ? eventos[eventos.length - 1] : null;
 
-                            if(Tel.timestamp < lastTimeStamp){
-                                distTotal = -1
-                            }else{
-                                console.log(safeNum(Tel.velocidade) * (safeNum(Tel.timestamp - lastTimeStamp)) / 1000)
-                                distTotal += safeNum(Tel.velocidade) * (safeNum(Tel.timestamp) - lastTimeStamp) / 1000;
-                                // distTotal += (safeNum(Tel.velMedia) * (safeNum(Tel.timestamp) - safeNum(lastTimeStamp)));
-                                lastTimeStamp = safeNum(Tel.timestamp);
-                            }
+                if (fimTs <= 0 && ultimaTel?.timestamp) {
+                    fimTs = safeNum(ultimaTel.timestamp);
+                }
+
+                const duration = (fimTs > inicioTs && inicioTs > 0) ? (fimTs - inicioTs) / 1000 : 0;
+                
+                eventos.forEach((tel: any) => {
+                    let Tel = Object(tel);
+                    if(distTotal !== -1){
+                        if(lastTimeStamp === 0) {
+                            lastTimeStamp = inicioTs;
                         }
-                    }) as any : null;
-                    const ultimaTel = corrida.telemetria ? Object.values(corrida.telemetria).pop() as any : null;
-                    const mahRestante = safeNum(ultimaTel?.mah_restante);
-                    return {
-                        id: firebaseId, // ID real para deletar
-                        displayId: index + 1, // ID visual da tabela
-                        datetime: new Date(corrida.metadados?.inicio_timestamp || Date.now()).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' }),
-                        size: `${corrida.metadados?.dimensao_labirinto || 16}x${corrida.metadados?.dimensao_labirinto || 16}` as any,
-                        status: corrida.metadados?.status || 'concluido',
-                        duracao: duration !== null && duration > 0 ? duration : 0,
-                        velocity: duration !== null && duration > 0 && distTotal !== -1? distTotal / duration : 0,
-                        consume: mahRestante > 0 ? 1000 - mahRestante : 0, 
-                        distance: distTotal !== -1? distTotal : 0
-                    };
+
+                        if(Tel.timestamp < lastTimeStamp){
+                            distTotal = -1;
+                        } else {
+                            distTotal += safeNum(Tel.velocidade) * (safeNum(Tel.timestamp) - lastTimeStamp) / 1000;
+                            lastTimeStamp = safeNum(Tel.timestamp);
+                        }
+                    }
                 });
-                setData(formatoTabela.reverse()); 
-            }).catch(console.error);
+
+                const mahRestante = safeNum(ultimaTel?.mah_restante);
+
+                const velocidadeMediaDashboard = eventos.length > 0
+                    ? eventos.reduce((acc: number, e: any) => acc + safeNum(e.velocidade), 0) / eventos.length
+                    : 0;
+
+                return {
+                    id: firebaseId, 
+                    displayId: index + 1, 
+                    datetime: new Date(inicioTs > 0 ? inicioTs : Date.now()).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' }),
+                    size: `${corrida.metadados?.dimensao_labirinto || 16}x${corrida.metadados?.dimensao_labirinto || 16}` as any,
+                    status: corrida.metadados?.status || 'concluido',
+                    duracao: duration, 
+                    velocity: velocidadeMediaDashboard, 
+                    consume: mahRestante > 0 ? 1000 - mahRestante : 0, 
+                    distance: distTotal !== -1 ? distTotal : 0
+                };
+            });
+            setData(formatoTabela.reverse()); 
+        }).catch(console.error);
     };
 
     useEffect(() => { fetchCorridas(); }, []);
@@ -104,10 +123,15 @@ export function Historico() {
         }
     };
 
-    return (
+   return (
         <>
             <div>
-                <Table columns={columns} data={data} onDelete={apagarCorrida} />
+                <Table 
+                    columns={columns} 
+                    data={data} 
+                    onDelete={apagarCorrida} 
+                    onRowClick={(id) => navigate(`/percurso/${id}`)} 
+                />
             </div>
         </>
     );

--- a/src/frontend/src/pages/Historico/Historico.tsx
+++ b/src/frontend/src/pages/Historico/Historico.tsx
@@ -25,7 +25,7 @@ const columns: Column<any>[] = [
             return <Badge size='sm' type={type} label={label} />;
         }
     },
-    { key: 'duracao', label: 'Duração', icon: 'timer', render: (value) => <p>{Number(value).toFixed(1)}s</p> },
+    { key: 'duracao', label: 'Duração', icon: 'timer', render: (value) => <p>{Number(value).toFixed(3)}s</p> },
     { key: 'velocity', label: 'Vel. Média', icon: 'speed', render: (value) => <p>{Number(value).toFixed(2)} m/s</p> },
     { key: 'consume', label: 'Consumo', icon: 'electric_bolt', render: (value) => <p>{Number(value).toFixed(0)} mAh</p> },
     { key: 'distance', label: 'Distância', icon: 'route', render: (value) => <p>{Number(value).toFixed(2)} m</p> },
@@ -42,6 +42,26 @@ export function Historico() {
 
                 const listaCorridas = Object.entries(dadosNode);
                 const formatoTabela = listaCorridas.map(([firebaseId, corrida]: any, index) => {
+                    let distTotal = 0;
+                    const duration =  corrida.telemetria ? (safeNum(corrida.metadados.fim_timestamp) - safeNum(corrida.metadados.inicio_timestamp)) / 1000: null;
+                    let lastTimeStamp = 0;
+                    corrida.telemetria ? Object.values(corrida.telemetria).forEach( (tel) =>{
+                        let Tel = Object(tel)
+                        if(distTotal !== -1){
+                            if(lastTimeStamp === 0) {
+                                lastTimeStamp = safeNum(corrida.metadados.inicio_timestamp)
+                            }
+
+                            if(Tel.timestamp < lastTimeStamp){
+                                distTotal = -1
+                            }else{
+                                console.log(safeNum(Tel.velocidade) * (safeNum(Tel.timestamp - lastTimeStamp)) / 1000)
+                                distTotal += safeNum(Tel.velocidade) * (safeNum(Tel.timestamp) - lastTimeStamp) / 1000;
+                                // distTotal += (safeNum(Tel.velMedia) * (safeNum(Tel.timestamp) - safeNum(lastTimeStamp)));
+                                lastTimeStamp = safeNum(Tel.timestamp);
+                            }
+                        }
+                    }) as any : null;
                     const ultimaTel = corrida.telemetria ? Object.values(corrida.telemetria).pop() as any : null;
                     const mahRestante = safeNum(ultimaTel?.mah_restante);
                     return {
@@ -50,10 +70,10 @@ export function Historico() {
                         datetime: new Date(corrida.metadados?.inicio_timestamp || Date.now()).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' }),
                         size: `${corrida.metadados?.dimensao_labirinto || 16}x${corrida.metadados?.dimensao_labirinto || 16}` as any,
                         status: corrida.metadados?.status || 'concluido',
-                        duracao: safeNum(ultimaTel?.tempoMedio),
-                        velocity: safeNum(ultimaTel?.velMedia),
+                        duracao: duration !== null && duration > 0 ? duration : 0,
+                        velocity: duration !== null && duration > 0 && distTotal !== -1? distTotal / duration : 0,
                         consume: mahRestante > 0 ? 1000 - mahRestante : 0, 
-                        distance: safeNum(ultimaTel?.distancia)
+                        distance: distTotal !== -1? distTotal : 0
                     };
                 });
                 setData(formatoTabela.reverse()); 

--- a/src/frontend/src/pages/Percurso/Percurso.tsx
+++ b/src/frontend/src/pages/Percurso/Percurso.tsx
@@ -80,7 +80,20 @@ export function Percurso() {
                     setUpdates(paredesFormatadas);
                 }
                 
-                if (dadosSelecionados.estado_atual?.posicao_vetor !== undefined) {
+                // CORREÇÃO: Carregar o trajeto completo no histórico para desenhar a linha laranja
+                if (isConsulta && dadosSelecionados.telemetria) {
+                    const eventosHistorico = Object.values(dadosSelecionados.telemetria) as any[];
+                    const caminhoCompleto = eventosHistorico
+                        .map(tel => tel.posicao_vetor)
+                        .filter(pos => pos !== undefined);
+                    
+                    if (caminhoCompleto.length > 0) {
+                        setPath(caminhoCompleto);
+                    } else if (dadosSelecionados.estado_atual?.posicao_vetor !== undefined) {
+                        setPath([dadosSelecionados.estado_atual.posicao_vetor]);
+                    }
+                } else if (dadosSelecionados.estado_atual?.posicao_vetor !== undefined) {
+                    // Mantém o comportamento original caso não seja histórico ou não tenha telemetria
                     setPath([dadosSelecionados.estado_atual.posicao_vetor]);
                 }
 

--- a/src/frontend/src/pages/Percurso/Percurso.tsx
+++ b/src/frontend/src/pages/Percurso/Percurso.tsx
@@ -8,10 +8,16 @@ import { Chart } from '../../components/Chart';
 import { Log } from '../../components/Log';
 import { Modal } from '../../components/Modal';
 import styles from './Percurso.module.css';
+import { useParams } from 'react-router-dom'; 
+
+const safeNum = (val: any) => { const n = Number(val); return isNaN(n) ? 0 : n; };
 
 interface LogEntry { time: string; message: string; type: 'info' | 'success' | 'warning'; }
 
 export function Percurso() {
+    const { id: idConsulta } = useParams(); 
+    const isConsulta = !!idConsulta; 
+
     const [idCorridaAtual, setIdCorridaAtual] = useState('');
     const [shortId, setShortId] = useState('000');
     const [mazeSize, setMazeSize] = useState(16);
@@ -23,7 +29,7 @@ export function Percurso() {
     const distanciaAtualRef = useRef(0); 
 
     const [telemetria, setTelemetria] = useState({
-        status: 'Aguardando...', tempo: '0.0s', velocidade: '0.00 m/s',
+        status: 'Aguardando...', tempo: '0.000s', velocidade: '0.00 m/s',
         distancia: '0.00 m', amperagem: '0 mA', voltagem: '0.0 V'
     });
 
@@ -43,52 +49,133 @@ export function Percurso() {
                 if (!dadosNode) return;
 
                 const corridas = Object.entries(dadosNode);
-                const indexUltima = corridas.length - 1;
-                const [idUltima, dadosUltima] = corridas[indexUltima] as [string, any];
                 
-                setIdCorridaAtual(idUltima);
-                setShortId(String(indexUltima + 1).padStart(3, '0')); 
+                let idSelecionado = '';
+                let dadosSelecionados: any = null;
+                let indexCorrida = 0;
 
-                if (dadosUltima.metadados?.dimensao_labirinto) setMazeSize(dadosUltima.metadados.dimensao_labirinto);
+                if (isConsulta && dadosNode[idConsulta]) {
+                    idSelecionado = idConsulta;
+                    dadosSelecionados = dadosNode[idConsulta];
+                    indexCorrida = corridas.findIndex(([key]) => key === idConsulta);
+                } else {
+                    const indexUltima = corridas.length - 1;
+                    const [idUltima, dadosUltima] = corridas[indexUltima] as [string, any];
+                    idSelecionado = idUltima;
+                    dadosSelecionados = dadosUltima;
+                    indexCorrida = indexUltima + 1;
+                    
+                    
+                }
 
-                if (dadosUltima.labirinto) {
-                    const paredesFormatadas = Object.entries(dadosUltima.labirinto).map(([chave, celula]: [string, any]) => {
+                setIdCorridaAtual(idSelecionado);
+                setShortId(String(indexCorrida + 1).padStart(3, '0')); 
+                if (dadosSelecionados.metadados?.dimensao_labirinto) setMazeSize(dadosSelecionados.metadados.dimensao_labirinto);
+
+                if (dadosSelecionados.labirinto) {
+                    const paredesFormatadas = Object.entries(dadosSelecionados.labirinto).map(([chave, celula]: [string, any]) => {
                         const index = parseInt(chave.split('_')[1] || "0");
                         return { index, walls: { top: celula.n, bottom: celula.s, right: celula.l, left: celula.o } };
                     });
                     setUpdates(paredesFormatadas);
                 }
-                if (dadosUltima.estado_atual?.posicao_vetor !== undefined) setPath([dadosUltima.estado_atual.posicao_vetor]);
+                
+                if (dadosSelecionados.estado_atual?.posicao_vetor !== undefined) {
+                    setPath([dadosSelecionados.estado_atual.posicao_vetor]);
+                }
+
+                if (isConsulta && dadosSelecionados) {
+                    const STATUS_MAP: Record<string, string> = {
+                        'concluido': 'Concluído', 
+                        'interrompida': 'Interrompido', 
+                        'em_execucao': 'Em curso'
+                    };
+                    const statusRaw = dadosSelecionados.metadados?.status || 'concluido';
+                    const statusFormatado = STATUS_MAP[statusRaw.toLowerCase()] || 'Desconhecido';
+
+                    let distTotal = 0;
+                    let lastTimeStamp = 0;
+                    const inicioTs = safeNum(dadosSelecionados.metadados?.inicio_timestamp);
+                    let fimTs = safeNum(dadosSelecionados.metadados?.fim_timestamp);
+
+                    const eventos = dadosSelecionados.telemetria ? Object.values(dadosSelecionados.telemetria) as any[] : [];
+                    const ultimaTel = eventos.length > 0 ? eventos[eventos.length - 1] : null;
+
+                    if (fimTs <= 0 && ultimaTel?.timestamp) {
+                        fimTs = safeNum(ultimaTel.timestamp);
+                    } 
+
+                    const duration = (fimTs > inicioTs && inicioTs > 0) ? (fimTs - inicioTs) / 1000 : 0;
+                    const chartData: any[] = [];
+
+                    eventos.forEach((tel: any) => {
+                        let Tel = Object(tel);
+                        if (distTotal !== -1) {
+                            if (lastTimeStamp === 0) lastTimeStamp = inicioTs;
+                            if (Tel.timestamp < lastTimeStamp) {
+                                distTotal = -1;
+                            } else {
+                                distTotal += safeNum(Tel.velocidade) * (safeNum(Tel.timestamp) - lastTimeStamp) / 1000;
+                                lastTimeStamp = safeNum(Tel.timestamp);
+                            }
+                        }
+
+                        chartData.push({
+                            ...Tel,
+                            velocidade: safeNum(Tel.velocidade) || safeNum(Tel.velMedia),
+                            tensao: safeNum(Tel.tensao) || safeNum(Tel.voltagem),
+                            corrente: safeNum(Tel.corrente),
+                            distancia: distTotal !== -1 ? distTotal : 0,
+                            timestamp: Tel.timestamp ?? Date.now()
+                        });
+                    });
+
+                    setPoints(chartData); 
+
+                    const velocidadeMediaDashboard = eventos.length > 0
+                        ? eventos.reduce((acc: number, e: any) => acc + safeNum(e.velocidade), 0) / eventos.length
+                        : 0;
+
+                    setTelemetria({
+                        status: statusFormatado,
+                        tempo: `${duration.toFixed(3)}s`,
+                        velocidade: `${velocidadeMediaDashboard.toFixed(2)} m/s`,
+                        distancia: `${distTotal !== -1 ? distTotal.toFixed(2) : '0.00'} m`,
+                        amperagem: ultimaTel?.corrente !== undefined ? `${ultimaTel.corrente} mA` : '0 mA',
+                        voltagem: ultimaTel?.tensao !== undefined ? `${ultimaTel.tensao} V` : (ultimaTel?.voltagem !== undefined ? `${ultimaTel.voltagem} V` : '0.0 V')
+                    });
+                }
             }).catch(console.error);
 
-        socket.on('novaPosicao', (novaPos: number) => setPath(prev => [...prev, novaPos]));
-        socket.on('novaParede', (dado: any) => setUpdates(prev => [...prev, { index: dado.celula, walls: { top: dado.n, bottom: dado.s, right: dado.l, left: dado.o } }]));
+        if (!isConsulta) {
+            socket.on('novaPosicao', (novaPos: number) => setPath(prev => [...prev, novaPos]));
+            socket.on('novaParede', (dado: any) => setUpdates(prev => [...prev, { index: dado.celula, walls: { top: dado.n, bottom: dado.s, right: dado.l, left: dado.o } }]));
 
-        socket.on('novaTelemetria', (dado: any) => {
-            if (dado.distancia !== undefined) {
-                distanciaAtualRef.current = dado.distancia;
-            }
+            socket.on('novaTelemetria', (dado: any) => {
+                if (dado.distancia !== undefined) {
+                    distanciaAtualRef.current = dado.distancia;
+                }
 
-            setTelemetria(prev => ({
-                ...prev,
-                status: dado.status || prev.status,
-                tempo: dado.tempoMedio !== undefined ? `${dado.tempoMedio}s` : prev.tempo,
-                velocidade: dado.velocidade !== undefined ? `${dado.velocidade} m/s` : prev.velocidade,
-                distancia: dado.distancia !== undefined ? `${dado.distancia} m` : prev.distancia,
-                amperagem: dado.corrente !== undefined ? `${dado.corrente} mA` : prev.amperagem,
-                voltagem: dado.tensao !== undefined ? `${dado.tensao} V` : prev.voltagem
-            }));
-
-            
-            setPoints(prev => [...prev, {
-                ...dado,
-                distancia: distanciaAtualRef.current,
-                timestamp: dado.timestamp ?? Date.now(),
-            }]);
-        });
+                setTelemetria(prev => ({
+                    ...prev,
+                    status: dado.status || prev.status,
+                    tempo: dado.tempoMedio !== undefined ? `${dado.tempoMedio}s` : prev.tempo,
+                    velocidade: dado.velocidade !== undefined ? `${dado.velocidade} m/s` : prev.velocidade,
+                    distancia: dado.distancia !== undefined ? `${dado.distancia} m` : prev.distancia,
+                    amperagem: dado.corrente !== undefined ? `${dado.corrente} mA` : prev.amperagem,
+                    voltagem: dado.tensao !== undefined ? `${dado.tensao} V` : prev.voltagem
+                }));
+                
+                setPoints(prev => [...prev, {
+                    ...dado,
+                    distancia: distanciaAtualRef.current,
+                    timestamp: dado.timestamp ?? Date.now(),
+                }]);
+            });
+        }
 
         return () => { socket.off('novaPosicao'); socket.off('novaParede'); socket.off('novaTelemetria'); };
-    }, []);
+    }, [isConsulta, idConsulta]); 
 
     useEffect(() => {
         if (path.length === 0) return;
@@ -107,7 +194,7 @@ export function Percurso() {
 
     const enviarComando = (comando: string) => {
         if (comando === 'iniciar') {
-            distanciaAtualRef.current = 0; // reseta a distância acumulada
+            distanciaAtualRef.current = 0; 
             setTelemetria(prev => ({ ...prev, status: 'Em execução', tempo: '0.0s', velocidade: '0.00 m/s', distancia: '0.00 m', amperagem: '0 mA', voltagem: '0.0 V' }));
             setPath([]); setUpdates([]); setLogs([]); setPoints([]);    
             addLog('Exploração iniciada', 'info');
@@ -122,7 +209,7 @@ export function Percurso() {
         }
 
         if (comando === 'reiniciar' || comando === 'cancelar') {
-            distanciaAtualRef.current = 0; // reseta a distância acumulada
+            distanciaAtualRef.current = 0; 
             setPath([]); setUpdates([]); setLogs([]); setPoints([]);
             setTelemetria(prev => ({ ...prev, status: comando === 'cancelar' ? 'Cancelado' : 'Aguardando...' }));
             addLog(`Percurso ${comando}`, 'info');
@@ -134,9 +221,12 @@ export function Percurso() {
         socket.emit('sendcomand', { id_corrida: idCorridaAtual, comando });
     };
 
+    const statusLower = String(telemetria.status).toLowerCase();
+    const rotuloTempo = statusLower.includes('conclu') ? 'Tempo de Resolução' : 'Tempo de Tentativa';
+
     const cards = [
         { icon: 'analytics', label: 'Status do Percurso', value: telemetria.status },
-        { icon: 'timer', label: 'Tempo de Resolução', value: telemetria.tempo },
+        { icon: 'timer', label: rotuloTempo, value: telemetria.tempo }, 
         { icon: 'speed', label: 'Velocidade Atual', value: telemetria.velocidade },
         { icon: 'route', label: 'Distância Percorrida', value: telemetria.distancia },
         { icon: 'battery_charging_full', label: 'Corrente Atual', value: telemetria.amperagem },
@@ -147,13 +237,15 @@ export function Percurso() {
         <div className={styles.MainTest}>
             <section>
                 <div className={styles.TopInfos}>
-                    <h2>Percurso #{shortId}</h2>
+                    <h2>{isConsulta ? 'Percurso' : 'Percurso'} #{shortId}</h2>
                     <div>
-                        <ControlBtn 
-                            onStart={() => enviarComando('iniciar')} onPause={() => enviarComando('pausar')}
-                            onResume={() => enviarComando('continuar')} onCancel={() => enviarComando('cancelar')}
-                            onRestart={() => enviarComando('reiniciar')}
-                        />
+                        {!isConsulta && (
+                            <ControlBtn 
+                                onStart={() => enviarComando('iniciar')} onPause={() => enviarComando('pausar')}
+                                onResume={() => enviarComando('continuar')} onCancel={() => enviarComando('cancelar')}
+                                onRestart={() => enviarComando('reiniciar')}
+                            />
+                        )}
                     </div>
                 </div>
 
@@ -191,7 +283,6 @@ export function Percurso() {
             >
                 <div>
                     <Log entries={logs} standalone={false} />
-
                 </div>
             </Modal>
         )}


### PR DESCRIPTION
## Tipo de mudança

Quais tipos de mudança o seu código aplica no repositório?
- [x] Fix de bug (fix de um problema sem risco de quebrar código).
- [ ] Atualização de documentação.

## Checklist - documentação

_Ponha um `x` nas caixinhas onde isso se aplica ou clique nelas para dar check caso esteja no PR do GitHub_ 

- [x] Eu fiz o git pull para pegar as novas atualizações.
- [ ] Eu [citei e referenciei apropriadamente](https://www.marilia.unesp.br/#!/laboratorio-editorial/procedimentos-publicacoes/normas-da-abnt--citacoes-e-referencias/) as fontes que utilizei em todo texto dentro do arquivo ou documento caso esteja mexendo com documentação.
- [ ] Eu testei o código localmente pela extensão LaTeX Workshop e atesto que o PDF foi devidamente gerado caso esteja mexendo com documentação.
- [x] **Atesto que, para este PR ser aprovado, preciso ter ao menos 5 checks nas caixinhas do "tipo de mudança" e "checklist da documentação". Caso não consiga cumprir com esta condição, irei fechar o PR (no final da página) e farei as mudanças necessárias até completar a quantidade de checks** 

## Resumo do que foi feito

### Correção de Bugs

- Cancelamento de corrida: O botão "Cancelar" agora altera o status do percurso para "Interrompido" no banco de dados. Antes, o percurso ficava travado em "Em curso" e só encerrava quando perdia a conexão (ao dar F5 na página).
- Numeração de Novos Percursos: Corrigido o bug visual no ID da corrida ao iniciar um novo teste. Agora, se a última corrida foi N, a tela de novo percurso exibe corretamente N + 1 no cabeçalho (antes, o visual travava no ID N).
- Cálculo da Velocidade Média:  Antes no histórico a velocidade média era calculada utilizando divisão simples (distância/tempo), em vez de  calcular a média  de todas as velocidades enviadas pela telemetria do robô (assim como é nos gráficos do dashboard).
- Cálculo de Duração: Corrigida a lógica de visualização do tempo de duração no histórico para corridas que não terminaram com sucesso.
- Status de Percurso: no backend há apenas 3 status: interrompido, concluido e em em_execucao, porém no front tinha um quarto "falhou", que foi removido. 

### Novas Features

- Consulta de Percursos Anteriores: ao clicar em uma corrida no histórico é redirecionado para uma tela onde é puxado todos os detalhes dessa corrida específica.
- Interface de Percurso Dinâmico:  Se for iniciar uma nova corrida, exibe "Novo Percurso". Se for visualização de uma corrida passada, "Consulta de Percurso".
